### PR TITLE
change ":" char to "/" char to make install successful

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "pmx": "*",
-    "pty.js": "git+ssh://git@github.com:Unitech/tty.js.git"
+    "pty.js": "git+ssh://git@github.com/Unitech/tty.js.git"
   },
   "apps": [
     {


### PR DESCRIPTION
'pm2 install pm2-ssh' failed with wrong tty.js url. Change ":" to "/". 
