### PR TITLE
version bump for node 10.13.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "pmx": "^0.5.5",
-    "tty.js": "^0.2.15"
+    "tty.js": "github:p-mcgowan/tty.js"
   },
   "config": {
     "port": "8080",
@@ -16,8 +16,8 @@
     "password": "bar",
     "https": "false",
     "bind": "0.0.0.0",
-    "ssl_key" : "./term-default.key",
-    "ssl_cert" : "./term-default.crt"
+    "ssl_key": "./term-default.key",
+    "ssl_cert": "./term-default.crt"
   },
   "keywords": [
     "webshell",
@@ -33,12 +33,15 @@
   "apps": [
     {
       "script": "app.js",
-      "name" : "pm2-webshell",
+      "name": "pm2-webshell",
       "max_memory_restart": "100M",
       "merge_logs": true,
-      "interpreter" : "node@4.8.4"
+      "interpreter": "node@4.8.4"
     }
   ],
-  "author": ["keymetrics", "JNK"],
+  "author": [
+    "keymetrics",
+    "JNK"
+  ],
   "license": "ISC"
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "pmx": "^0.5.5",
+    "@pm2/io": "^2.4.7",
     "tty.js": "github:p-mcgowan/tty.js"
   },
   "config": {


### PR DESCRIPTION
RE https://github.com/chjj/pty.js/issues/195 

Depends on pending PRs:
https://github.com/chjj/pty.js/pull/197
https://github.com/chjj/tty.js/pull/182

Not to be merged until those 2 forks get merged, and the package.json is updated with the newer associated npm versions.

Note: may also be related to https://github.com/pm2-hive/pm2-webshell/issues/22
